### PR TITLE
Add dynamic diff tx pow based on input + output

### DIFF
--- a/include/ITransaction.h
+++ b/include/ITransaction.h
@@ -134,7 +134,7 @@ namespace CryptoNote
         // signing
         virtual void signInputKey(size_t input, const TransactionTypes::InputKeyInfo &info, const KeyPair &ephKeys) = 0;
 
-        virtual void generateTxProofOfWork() = 0;
+        virtual void generateTxProofOfWork(const uint64_t height) = 0;
     };
 
     class ITransaction : public ITransactionReader, public ITransactionWriter

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -42,7 +42,7 @@ namespace CryptoNote
          * MINIMUM_UNLOCK_TIME_BLOCKS to be accepted. */
         const uint64_t MINIMUM_UNLOCK_TIME_BLOCKS = 15;
 
-        const uint64_t UNLOCK_TIME_HEIGHT = 1400000;
+        const uint64_t UNLOCK_TIME_HEIGHT = 1400000; // TODO: Update fork height
 
         const uint64_t CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT = 60 * 60 * 2;
 
@@ -226,6 +226,21 @@ namespace CryptoNote
         /* Tx difficulty will be 3 times from normal TX, in exchange of zero fee */
         const uint64_t FUSION_TRANSACTION_POW_DIFFICULTY = 3 * TRANSACTION_POW_DIFFICULTY;
 
+        /* Height of dynamic Tx PoW diff for each input output size */
+        const uint64_t TRANSACTION_POW_HEIGHT_DYN_V1 = 1400000; // TODO: Update fork height
+        
+        /* A minimum diff tx pow. Example, it will be 100000 + Multiplier * [Input + Output size()] */
+        const uint64_t TRANSACTION_POW_DIFFICULTY_DYN_V1 = 100000;
+        
+        /* Multiplier diff */
+        const uint64_t MULTIPLIER_TRANSACTION_POW_DIFFICULTY_PER_IO_V1 = 1000;
+        
+        /* Output / Input factor: how many times we factor Output diff. Assuming input is 1 */
+        const uint64_t MULTIPLIER_TRANSACTION_POW_DIFFICULTY_FACTORED_OUT_V1 = 4;
+
+        /* Tx difficulty will be 3 times of TRANSACTION_POW_DIFFICULTY_DYN_V1, in exchange of zero fee */
+        const uint64_t FUSION_TRANSACTION_POW_DIFFICULTY_V2 = 3 * TRANSACTION_POW_DIFFICULTY_DYN_V1;
+
         /* 12.5 trillion atomic, or 125 billion TRTL -> Max supply / mixin+1 outputs */
         /* This is enforced on the daemon side. An output > 125 billion causes
          * an invalid block. */
@@ -318,7 +333,7 @@ namespace CryptoNote
             864864,   // 10
             1000000,  // 11
             1123000,  // 12
-            1400000,  // 13
+            1400000,  // 13  // TODO: Update fork height
         };
 
         /* MAKE SURE TO UPDATE THIS VALUE WITH EVERY MAJOR RELEASE BEFORE A FORK */

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -230,7 +230,7 @@ namespace CryptoNote
         const uint64_t TRANSACTION_POW_HEIGHT_DYN_V1 = 1400000; // TODO: Update fork height
         
         /* A minimum diff tx pow. Example, it will be 40000 + Multiplier * [Input + Output size()] */
-        const uint64_t TRANSACTION_POW_DIFFICULTY_DYN_V1 = 40000;
+        const uint64_t TRANSACTION_POW_DIFFICULTY_DYN_V1 = 40000; // If this change, please look at FUSION_TRANSACTION_POW_DIFFICULTY_V2
         
         /* Multiplier diff */
         const uint64_t MULTIPLIER_TRANSACTION_POW_DIFFICULTY_PER_IO_V1 = 1000;
@@ -239,7 +239,7 @@ namespace CryptoNote
         const uint64_t MULTIPLIER_TRANSACTION_POW_DIFFICULTY_FACTORED_OUT_V1 = 4;
 
         /* Tx difficulty will be 3 times of TRANSACTION_POW_DIFFICULTY_DYN_V1, in exchange of zero fee */
-        const uint64_t FUSION_TRANSACTION_POW_DIFFICULTY_V2 = 3 * TRANSACTION_POW_DIFFICULTY_DYN_V1;
+        const uint64_t FUSION_TRANSACTION_POW_DIFFICULTY_V2 = 8 * TRANSACTION_POW_DIFFICULTY_DYN_V1;
 
         /* 12.5 trillion atomic, or 125 billion TRTL -> Max supply / mixin+1 outputs */
         /* This is enforced on the daemon side. An output > 125 billion causes

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -229,8 +229,8 @@ namespace CryptoNote
         /* Height of dynamic Tx PoW diff for each input output size */
         const uint64_t TRANSACTION_POW_HEIGHT_DYN_V1 = 1400000; // TODO: Update fork height
         
-        /* A minimum diff tx pow. Example, it will be 100000 + Multiplier * [Input + Output size()] */
-        const uint64_t TRANSACTION_POW_DIFFICULTY_DYN_V1 = 100000;
+        /* A minimum diff tx pow. Example, it will be 40000 + Multiplier * [Input + Output size()] */
+        const uint64_t TRANSACTION_POW_DIFFICULTY_DYN_V1 = 40000;
         
         /* Multiplier diff */
         const uint64_t MULTIPLIER_TRANSACTION_POW_DIFFICULTY_PER_IO_V1 = 1000;

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -412,9 +412,9 @@ namespace CryptoNote
 
     // P2P Network Configuration Section - This defines our current P2P network version
     // and the minimum version for communication between nodes
-    const uint8_t P2P_CURRENT_VERSION = 14;
+    const uint8_t P2P_CURRENT_VERSION = 15;
 
-    const uint8_t P2P_MINIMUM_VERSION = 13;
+    const uint8_t P2P_MINIMUM_VERSION = 14;
 
     // This defines the minimum P2P version required for lite blocks propogation
     const uint8_t P2P_LITE_BLOCKS_PROPOGATION_VERSION = 4;

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -42,7 +42,7 @@ namespace CryptoNote
          * MINIMUM_UNLOCK_TIME_BLOCKS to be accepted. */
         const uint64_t MINIMUM_UNLOCK_TIME_BLOCKS = 15;
 
-        const uint64_t UNLOCK_TIME_HEIGHT = 1400000; // TODO: Update fork height
+        const uint64_t UNLOCK_TIME_HEIGHT = 1200000;
 
         const uint64_t CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT = 60 * 60 * 2;
 
@@ -227,7 +227,7 @@ namespace CryptoNote
         const uint64_t FUSION_TRANSACTION_POW_DIFFICULTY = 3 * TRANSACTION_POW_DIFFICULTY;
 
         /* Height of dynamic Tx PoW diff for each input output size */
-        const uint64_t TRANSACTION_POW_HEIGHT_DYN_V1 = 1400000; // TODO: Update fork height
+        const uint64_t TRANSACTION_POW_HEIGHT_DYN_V1 = 1200000;
         
         /* A minimum diff tx pow. Example, it will be 40000 + Multiplier * [Input + Output size()] */
         const uint64_t TRANSACTION_POW_DIFFICULTY_DYN_V1 = 40000; // If this change, please look at FUSION_TRANSACTION_POW_DIFFICULTY_V2
@@ -333,11 +333,12 @@ namespace CryptoNote
             864864,   // 10
             1000000,  // 11
             1123000,  // 12
-            1400000,  // 13  // TODO: Update fork height
+            1200000,  // 13
+            1500000,  // 14  // TODO: Update fork height
         };
 
         /* MAKE SURE TO UPDATE THIS VALUE WITH EVERY MAJOR RELEASE BEFORE A FORK */
-        const uint64_t SOFTWARE_SUPPORTED_FORK_INDEX = 12;
+        const uint64_t SOFTWARE_SUPPORTED_FORK_INDEX = 13;
 
         const uint64_t FORK_HEIGHTS_SIZE = sizeof(FORK_HEIGHTS) / sizeof(*FORK_HEIGHTS);
 

--- a/src/cryptonotecore/Transaction.cpp
+++ b/src/cryptonotecore/Transaction.cpp
@@ -119,7 +119,7 @@ namespace CryptoNote
         virtual void
             signInputKey(size_t input, const TransactionTypes::InputKeyInfo &info, const KeyPair &ephKeys) override;
 
-        virtual void generateTxProofOfWork() override;
+        virtual void generateTxProofOfWork(const uint64_t height) override;
 
       private:
         void invalidateHash();
@@ -373,10 +373,10 @@ namespace CryptoNote
         transaction.extra.insert(transaction.extra.end(), extraData.begin(), extraData.end());
     }
 
-    void TransactionImpl::generateTxProofOfWork()
+    void TransactionImpl::generateTxProofOfWork(const uint64_t height)
     {
         checkIfSigning();
-        transaction.extra = SendTransaction::generateTransactionPoW(transaction, transaction.extra);
+        transaction.extra = SendTransaction::generateTransactionPoWHeight(transaction, transaction.extra, height);
     }
 
     bool TransactionImpl::getExtraNonce(BinaryArray &nonce) const

--- a/src/cryptonotecore/ValidateTransaction.cpp
+++ b/src/cryptonotecore/ValidateTransaction.cpp
@@ -569,6 +569,26 @@ bool ValidateTransaction::validateTransactionPoW()
 
     uint64_t diff = CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY_DYN_V1;
 
+    uint64_t txInputSize = 0;
+    try
+    {
+        txInputSize = m_transaction.inputs.size();
+    }
+    catch (const std::exception &e)
+    {
+        //
+    }
+
+    uint64_t txOutputSize = 0;
+    try
+    {
+        txOutputSize = m_transaction.outputs.size();
+    }
+    catch (const std::exception &e)
+    {
+        //
+    }
+
     if (m_blockHeight >= CryptoNote::parameters::TRANSACTION_POW_HEIGHT && 
     m_blockHeight <= CryptoNote::parameters::TRANSACTION_POW_HEIGHT_DYN_V1)
     {
@@ -577,7 +597,7 @@ bool ValidateTransaction::validateTransactionPoW()
     {
         diff = isFusion ? CryptoNote::parameters::FUSION_TRANSACTION_POW_DIFFICULTY_V2 : 
         (CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY_DYN_V1 
-        + (m_transaction.inputs.size() + m_transaction.outputs.size() * CryptoNote::parameters::MULTIPLIER_TRANSACTION_POW_DIFFICULTY_FACTORED_OUT_V1) 
+        + (txInputSize + txOutputSize * CryptoNote::parameters::MULTIPLIER_TRANSACTION_POW_DIFFICULTY_FACTORED_OUT_V1) 
         * CryptoNote::parameters::MULTIPLIER_TRANSACTION_POW_DIFFICULTY_PER_IO_V1);
     }
 

--- a/src/cryptonotecore/ValidateTransaction.cpp
+++ b/src/cryptonotecore/ValidateTransaction.cpp
@@ -567,7 +567,19 @@ bool ValidateTransaction::validateTransactionPoW()
 
     Crypto::cn_upx(data.data(), data.size(), hash);
 
-    const uint64_t diff = isFusion ? CryptoNote::parameters::FUSION_TRANSACTION_POW_DIFFICULTY : CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY;
+    uint64_t diff = CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY_DYN_V1;
+
+    if (m_blockHeight >= CryptoNote::parameters::TRANSACTION_POW_HEIGHT && 
+    m_blockHeight <= CryptoNote::parameters::TRANSACTION_POW_HEIGHT_DYN_V1)
+    {
+        diff = isFusion ? CryptoNote::parameters::FUSION_TRANSACTION_POW_DIFFICULTY : CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY;
+    } else if (m_blockHeight > CryptoNote::parameters::TRANSACTION_POW_HEIGHT_DYN_V1)
+    {
+        diff = isFusion ? CryptoNote::parameters::FUSION_TRANSACTION_POW_DIFFICULTY_V2 : 
+        (CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY_DYN_V1 
+        + (m_transaction.inputs.size() + m_transaction.outputs.size() * CryptoNote::parameters::MULTIPLIER_TRANSACTION_POW_DIFFICULTY_FACTORED_OUT_V1) 
+        * CryptoNote::parameters::MULTIPLIER_TRANSACTION_POW_DIFFICULTY_PER_IO_V1);
+    }
 
     if (CryptoNote::check_hash(hash, diff))
     {

--- a/src/wallet/WalletGreen.cpp
+++ b/src/wallet/WalletGreen.cpp
@@ -2879,7 +2879,8 @@ namespace CryptoNote
             tx->addInput(makeAccountKeys(*input.walletRecord), input.keyInfo, input.ephKeys);
         }
 
-        tx->generateTxProofOfWork();
+        uint32_t height = m_node.getLastKnownBlockHeight();
+        tx->generateTxProofOfWork(height);
 
         size_t i = 0;
         for (auto &input : keysInfo)

--- a/src/walletbackend/Transfer.cpp
+++ b/src/walletbackend/Transfer.cpp
@@ -18,6 +18,7 @@
 #include <utilities/Mixins.h>
 #include <utilities/Utilities.h>
 #include <walletbackend/WalletBackend.h>
+#include <ctime> // time_t
 
 namespace SendTransaction
 {
@@ -1459,7 +1460,36 @@ namespace SendTransaction
          * signature generation, as ring signatures take the transaction prefix
          * hash. Generating it afterwards would change the hash, and thus invalidate
          * the sigs. */
-        setupTX.extra = generateTransactionPoW(setupTX, extra);
+
+        Logger::logger.log(
+            "Tx PoW preparing",
+            Logger::DEBUG,
+            { Logger::TRANSACTIONS }
+        );
+
+        try
+        {
+            /* get time start and end for Tx PoW Log */
+            time_t time_begin, time_end; // time_t is a datatype to store time values.
+
+            time (&time_begin); // note time before execution
+
+            setupTX.extra = generateTransactionPoWHeight(setupTX, extra, daemon->networkBlockCount());
+
+            time (&time_end); // note time after execution
+
+            const double difference = difftime (time_end, time_begin);
+
+            Logger::logger.log(
+                "Tx PoW took " + std::to_string(difference) + " second(s)",
+                Logger::DEBUG,
+                { Logger::TRANSACTIONS }
+            );
+        }
+        catch (const std::exception &e)
+        {
+            std::cout << "Unhandled exception caught: " << e.what() << "\n..." << std::endl;
+        }
 
         /* Fill in the transaction signatures */
         /* NOTE: Do not modify the transaction after this, or the ring signatures
@@ -1561,7 +1591,7 @@ namespace SendTransaction
         uint64_t nonce,
         std::atomic<bool> &shouldStop,
         CryptoNote::Transaction tx,
-        const std::shared_ptr<Nigel> daemon)
+        const uint64_t height)
     {
         /* Make a thread local copy */
         auto extra = finalExtra;
@@ -1589,25 +1619,48 @@ namespace SendTransaction
 
             const uint64_t actualFee = sumTransactionFee(tx);
 
-            const bool isFusion = actualFee == 0 || (actualFee == CryptoNote::parameters::FUSION_FEE_V1 && daemon->networkBlockCount() >= CryptoNote::parameters::FUSION_FEE_V1_HEIGHT
-                && daemon->networkBlockCount() < CryptoNote::parameters::FUSION_ZERO_FEE_V2_HEIGHT);
+            const bool isFusion = actualFee == 0 || (actualFee == CryptoNote::parameters::FUSION_FEE_V1 && height >= CryptoNote::parameters::FUSION_FEE_V1_HEIGHT
+                && height < CryptoNote::parameters::FUSION_ZERO_FEE_V2_HEIGHT);
 
             uint64_t diff = CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY_DYN_V1;
             
-            if (daemon->networkBlockCount() >= CryptoNote::parameters::TRANSACTION_POW_HEIGHT && 
-            daemon->networkBlockCount() <= CryptoNote::parameters::TRANSACTION_POW_HEIGHT_DYN_V1)
+            uint64_t txInputSize = 0;
+            try
+            {
+                txInputSize = tx.inputs.size();
+            }
+            catch (const std::exception &e)
+            {
+            }
+
+            uint64_t txOutputSize = 0;
+            try
+            {
+                txOutputSize = tx.outputs.size();
+            }
+            catch (const std::exception &e)
+            {
+            }
+
+            if (height >= CryptoNote::parameters::TRANSACTION_POW_HEIGHT && 
+            height <= CryptoNote::parameters::TRANSACTION_POW_HEIGHT_DYN_V1)
             {
                 diff = isFusion ? CryptoNote::parameters::FUSION_TRANSACTION_POW_DIFFICULTY : CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY;
-            } else if (daemon->networkBlockCount() > CryptoNote::parameters::TRANSACTION_POW_HEIGHT_DYN_V1)
+            } else if (height > CryptoNote::parameters::TRANSACTION_POW_HEIGHT_DYN_V1)
             {
                 diff = isFusion ? CryptoNote::parameters::FUSION_TRANSACTION_POW_DIFFICULTY_V2 : 
                 (CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY_DYN_V1 
-                + (tx.inputs.size() + tx.outputs.size() * CryptoNote::parameters::MULTIPLIER_TRANSACTION_POW_DIFFICULTY_FACTORED_OUT_V1) 
+                + (txInputSize + txOutputSize * CryptoNote::parameters::MULTIPLIER_TRANSACTION_POW_DIFFICULTY_FACTORED_OUT_V1) 
                 * CryptoNote::parameters::MULTIPLIER_TRANSACTION_POW_DIFFICULTY_PER_IO_V1);
             }
 
             if (CryptoNote::check_hash(hash, diff))
             {
+                Logger::logger.log(
+                    "Making Tx PoW with difficulty " + std::to_string(diff),
+                    Logger::DEBUG,
+                    { Logger::TRANSACTIONS }
+                );
                 finalExtra = extra;
                 shouldStop = true;
 
@@ -1618,9 +1671,10 @@ namespace SendTransaction
         }
     }
 
-    std::vector<uint8_t> generateTransactionPoW(
+    std::vector<uint8_t> generateTransactionPoWHeight(
         CryptoNote::Transaction tx,
-        std::vector<uint8_t> extra)
+        std::vector<uint8_t> extra,
+        const uint64_t height)
     {
         /* Add the nonce identifier */
         extra.push_back(Constants::TX_EXTRA_TRANSACTION_POW_NONCE_IDENTIFIER);
@@ -1645,7 +1699,7 @@ namespace SendTransaction
                 i,
                 std::ref(shouldStop),
                 tx,
-                daemon
+                height
             ));
         }
 

--- a/src/walletbackend/Transfer.cpp
+++ b/src/walletbackend/Transfer.cpp
@@ -1592,7 +1592,20 @@ namespace SendTransaction
             const bool isFusion = actualFee == 0 || (actualFee == CryptoNote::parameters::FUSION_FEE_V1 && daemon->networkBlockCount() >= CryptoNote::parameters::FUSION_FEE_V1_HEIGHT
                 && daemon->networkBlockCount() < CryptoNote::parameters::FUSION_ZERO_FEE_V2_HEIGHT);
 
-            const uint64_t diff = isFusion ? CryptoNote::parameters::FUSION_TRANSACTION_POW_DIFFICULTY : CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY;
+            uint64_t diff = CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY_DYN_V1;
+            
+            if (daemon->networkBlockCount() >= CryptoNote::parameters::TRANSACTION_POW_HEIGHT && 
+            daemon->networkBlockCount() <= CryptoNote::parameters::TRANSACTION_POW_HEIGHT_DYN_V1)
+            {
+                diff = isFusion ? CryptoNote::parameters::FUSION_TRANSACTION_POW_DIFFICULTY : CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY;
+            } else if (daemon->networkBlockCount() > CryptoNote::parameters::TRANSACTION_POW_HEIGHT_DYN_V1)
+            {
+                diff = isFusion ? CryptoNote::parameters::FUSION_TRANSACTION_POW_DIFFICULTY_V2 : 
+                (CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY_DYN_V1 
+                + (tx.inputs.size() + tx.outputs.size() * CryptoNote::parameters::MULTIPLIER_TRANSACTION_POW_DIFFICULTY_FACTORED_OUT_V1) 
+                * CryptoNote::parameters::MULTIPLIER_TRANSACTION_POW_DIFFICULTY_PER_IO_V1);
+            }
+
             if (CryptoNote::check_hash(hash, diff))
             {
                 finalExtra = extra;

--- a/src/walletbackend/Transfer.cpp
+++ b/src/walletbackend/Transfer.cpp
@@ -1643,10 +1643,10 @@ namespace SendTransaction
             }
 
             if (height >= CryptoNote::parameters::TRANSACTION_POW_HEIGHT && 
-            height <= CryptoNote::parameters::TRANSACTION_POW_HEIGHT_DYN_V1)
+            height < CryptoNote::parameters::TRANSACTION_POW_HEIGHT_DYN_V1)
             {
                 diff = isFusion ? CryptoNote::parameters::FUSION_TRANSACTION_POW_DIFFICULTY : CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY;
-            } else if (height > CryptoNote::parameters::TRANSACTION_POW_HEIGHT_DYN_V1)
+            } else if (height >= CryptoNote::parameters::TRANSACTION_POW_HEIGHT_DYN_V1)
             {
                 diff = isFusion ? CryptoNote::parameters::FUSION_TRANSACTION_POW_DIFFICULTY_V2 : 
                 (CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY_DYN_V1 

--- a/src/walletbackend/Transfer.h
+++ b/src/walletbackend/Transfer.h
@@ -155,9 +155,10 @@ namespace SendTransaction
         const uint64_t height,
         const CryptoNote::Transaction tx);
 
-    std::vector<uint8_t> generateTransactionPoW(
+    std::vector<uint8_t> generateTransactionPoWHeight(
         CryptoNote::Transaction tx,
-        std::vector<uint8_t> extra);
+        std::vector<uint8_t> extra,
+        const uint64_t height);
 
     /* Template so we can do transaction, and transactionprefix */
     template<typename T> Crypto::Hash getTransactionHash(T tx)


### PR DESCRIPTION
* Update implementation of Tx PoW with dynamic difficulty based on numbers of inputs + outputs
* Same algo (`cn_upx`)
* A minimum required difficulty starts with ~~**100,000**~~ **40,000** and increased by `MULTIPLIER_TRANSACTION_POW_DIFFICULTY_PER_IO_V1 = 1000` per each input plus **4x** (`MULTIPLIER_TRANSACTION_POW_DIFFICULTY_PER_IO_V1 = 1000`) per each output
* Fusion Tx PoW difficulty will be constantly ~~**300,000**~~ 8x40,000 = **320,000**

#### TODO
* ~~Test a basic network~~ (tested)
* ~~Test with a separated chain of WrkzCoin~~ (tested)
* ~~Update fork height~~
* ~~Update p2p version~~