### PR TITLE
Fee per byte v2

### DIFF
--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -123,7 +123,7 @@ namespace CryptoNote
         const uint64_t FEE_PER_BYTE_CHUNK_SIZE = 256;
 
         /* Fork fee per byte v2 */
-        const uint64_t FEE_PER_BYTE_CHUNK_SIZE_V2 = 16; // TODO Fee v2 = FEE_PER_BYTE_CHUNK_SIZE / 16
+        const uint64_t FEE_PER_BYTE_CHUNK_SIZE_V2 = 128; // TODO Fee v2 = FEE_PER_BYTE_CHUNK_SIZE
 
         /* Fee to charge per byte of transaction. Will be applied in chunks, see
          * above. This value comes out to 1.953125. We use this value instead of
@@ -132,7 +132,7 @@ namespace CryptoNote
          * is 500 atomic units. The fee per byte is 500 / chunk size. */
         const double MINIMUM_FEE_PER_BYTE_V1 = 500.00 / FEE_PER_BYTE_CHUNK_SIZE;
 
-        const double MINIMUM_FEE_PER_BYTE_V2 = 50.00 / FEE_PER_BYTE_CHUNK_SIZE_V2; // TODO Fee v2 = MINIMUM_FEE_PER_BYTE_V1 / 10
+        const double MINIMUM_FEE_PER_BYTE_V2 = 10.00 / FEE_PER_BYTE_CHUNK_SIZE_V2; // TODO Fee v2 = MINIMUM_FEE_PER_BYTE_V1
 
         /* Height for our first fee to byte change to take effect. */
         const uint64_t MINIMUM_FEE_PER_BYTE_V1_HEIGHT  = 832000;

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -38,11 +38,17 @@ namespace CryptoNote
          * before becoming invalid. */
         const uint64_t UNLOCK_TIME_TRANSACTION_POOL_WINDOW = 40;
 
+        /* Unlock V2 */
+        const uint64_t UNLOCK_TIME_TRANSACTION_POOL_WINDOW_V2 = 10;
+
         /* Transactions must have an unlock time of at least current block +
          * MINIMUM_UNLOCK_TIME_BLOCKS to be accepted. */
         const uint64_t MINIMUM_UNLOCK_TIME_BLOCKS = 15;
 
         const uint64_t UNLOCK_TIME_HEIGHT = 1200000;
+
+        /* Unlock V2 */
+        const uint64_t UNLOCK_TIME_HEIGHT_V2 = 1500000; // TODO
 
         const uint64_t CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT = 60 * 60 * 2;
 

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -116,6 +116,9 @@ namespace CryptoNote
          * to the underlying storage cost / page sizes for storing a transaction. */
         const uint64_t FEE_PER_BYTE_CHUNK_SIZE = 256;
 
+        /* Fork fee per byte v2 */
+        const uint64_t FEE_PER_BYTE_CHUNK_SIZE_V2 = 16; // TODO Fee v2 = FEE_PER_BYTE_CHUNK_SIZE / 16
+
         /* Fee to charge per byte of transaction. Will be applied in chunks, see
          * above. This value comes out to 1.953125. We use this value instead of
          * something like 2 because it makes for pretty resulting fees
@@ -123,8 +126,13 @@ namespace CryptoNote
          * is 500 atomic units. The fee per byte is 500 / chunk size. */
         const double MINIMUM_FEE_PER_BYTE_V1 = 500.00 / FEE_PER_BYTE_CHUNK_SIZE;
 
+        const double MINIMUM_FEE_PER_BYTE_V2 = 50.00 / FEE_PER_BYTE_CHUNK_SIZE_V2; // TODO Fee v2 = MINIMUM_FEE_PER_BYTE_V1 / 10
+
         /* Height for our first fee to byte change to take effect. */
         const uint64_t MINIMUM_FEE_PER_BYTE_V1_HEIGHT  = 832000;
+        
+        /* Fork fee per byte v2 */
+        const uint64_t MINIMUM_FEE_PER_BYTE_V2_HEIGHT  = 1500000; // TODO Fee v2
 
         /* This section defines our minimum and maximum mixin counts required for transactions */
         const uint64_t MINIMUM_MIXIN_V1 = 0;

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -39,7 +39,7 @@ namespace CryptoNote
         const uint64_t UNLOCK_TIME_TRANSACTION_POOL_WINDOW = 40;
 
         /* Unlock V2 */
-        const uint64_t UNLOCK_TIME_TRANSACTION_POOL_WINDOW_V2 = 15;
+        const uint64_t UNLOCK_TIME_TRANSACTION_POOL_WINDOW_V2 = 20;
 
         /* Transactions must have an unlock time of at least current block +
          * MINIMUM_UNLOCK_TIME_BLOCKS to be accepted. */

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -450,7 +450,7 @@ namespace CryptoNote
     const size_t P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT = 5000; // 5 seconds
     const char P2P_STAT_TRUSTED_PUB_KEY[] = "";
 
-    const uint64_t ROCKSDB_WRITE_BUFFER_MB = 32; // 32 MB
+    const uint64_t ROCKSDB_WRITE_BUFFER_MB = 4; // 4 MB
     const uint64_t ROCKSDB_READ_BUFFER_MB = 256; // 256 MB
     const uint64_t ROCKSDB_MAX_OPEN_FILES = 512; // 512 files
     const uint64_t ROCKSDB_BACKGROUND_THREADS = 8; // 4 DB threads

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -39,7 +39,7 @@ namespace CryptoNote
         const uint64_t UNLOCK_TIME_TRANSACTION_POOL_WINDOW = 40;
 
         /* Unlock V2 */
-        const uint64_t UNLOCK_TIME_TRANSACTION_POOL_WINDOW_V2 = 10;
+        const uint64_t UNLOCK_TIME_TRANSACTION_POOL_WINDOW_V2 = 15;
 
         /* Transactions must have an unlock time of at least current block +
          * MINIMUM_UNLOCK_TIME_BLOCKS to be accepted. */

--- a/src/config/version.h.in
+++ b/src/config/version.h.in
@@ -6,8 +6,8 @@
 #define PROJECT_COPYRIGHT "Copyright 2018-2020, The WrkzCoin Developers"
 #define APP_VER_MAJOR 0
 #define APP_VER_MINOR 3
-#define APP_VER_REV 5
-#define APP_VER_BUILD 170
+#define APP_VER_REV 6
+#define APP_VER_BUILD 180
 
 #define BUILD_COMMIT_ID "@VERSION@"
 #define PROJECT_VERSION STR(APP_VER_MAJOR) "." STR(APP_VER_MINOR) "." STR(APP_VER_REV)

--- a/src/cryptonotecore/ValidateTransaction.cpp
+++ b/src/cryptonotecore/ValidateTransaction.cpp
@@ -425,6 +425,7 @@ bool ValidateTransaction::validateTransactionFee()
     {
         validFee = fee != 0;
 
+        /* getMinimumTransactionFee shall get fee dynamically for v1 and v2 */
         if (m_blockHeight >= CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1_HEIGHT)
         {
             const auto minFee = Utilities::getMinimumTransactionFee(

--- a/src/errors/ValidateParameters.cpp
+++ b/src/errors/ValidateParameters.cpp
@@ -251,7 +251,14 @@ Error validateAmount(
     }
 
     /* Using a fee per byte, and doesn't meet the min fee per byte requirement. */
-    if (fee.isFeePerByte && fee.feePerByte < CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1)
+    double min_fee = CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1;
+    
+    if (currentHeight > CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V2_HEIGHT)
+    {
+        min_fee = CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V2;
+    }
+
+    if (fee.isFeePerByte && fee.feePerByte < min_fee)
     {
         return FEE_TOO_SMALL;
     }

--- a/src/utilities/Utilities.cpp
+++ b/src/utilities/Utilities.cpp
@@ -229,7 +229,7 @@ namespace Utilities
         {
             return CryptoNote::parameters::MINIMUM_FEE_V1;
         }
-        else
+        else if (height < CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V2_HEIGHT)
         {
             const uint64_t numChunks = static_cast<uint64_t>(std::ceil(
                 transactionSize / static_cast<double>(CryptoNote::parameters::FEE_PER_BYTE_CHUNK_SIZE)
@@ -239,16 +239,32 @@ namespace Utilities
                 numChunks * feePerByte * CryptoNote::parameters::FEE_PER_BYTE_CHUNK_SIZE
             );
         }
+        else
+        {
+            const uint64_t numChunks = static_cast<uint64_t>(std::ceil(
+                transactionSize / static_cast<double>(CryptoNote::parameters::FEE_PER_BYTE_CHUNK_SIZE_V2)
+            ));
+
+            return static_cast<uint64_t>(
+                numChunks * feePerByte * CryptoNote::parameters::FEE_PER_BYTE_CHUNK_SIZE_V2
+            );
+        }
     }
 
     uint64_t getMinimumTransactionFee(
         const size_t transactionSize,
         const uint64_t height)
     {
+        double fee = CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1;
+        
+        if (height > CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1)
+        {
+            fee = CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V2;
+        }
         return getTransactionFee(
             transactionSize,
             height,
-            CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1
+            fee
         );
     }
 

--- a/src/wallet/WalletGreen.cpp
+++ b/src/wallet/WalletGreen.cpp
@@ -1637,8 +1637,15 @@ namespace CryptoNote
     {
         if (transactionParameters.unlockTimestamp == 0)
         {
+            uint64_t unlock_blocks = CryptoNote::parameters::UNLOCK_TIME_TRANSACTION_POOL_WINDOW;
+
+            if (m_node.getLastKnownBlockHeight() > CryptoNote::parameters::UNLOCK_TIME_HEIGHT_V2)
+            {
+                unlock_blocks = CryptoNote::parameters::UNLOCK_TIME_TRANSACTION_POOL_WINDOW_V2;
+            }
+
             transactionParameters.unlockTimestamp = m_node.getLastKnownBlockHeight()
-                + CryptoNote::parameters::UNLOCK_TIME_TRANSACTION_POOL_WINDOW
+                + unlock_blocks
                 + CryptoNote::parameters::MINIMUM_UNLOCK_TIME_BLOCKS;
         }
 
@@ -2235,8 +2242,15 @@ namespace CryptoNote
     {
         if (sendingTransaction.unlockTimestamp == 0)
         {
+            uint64_t unlock_blocks = CryptoNote::parameters::UNLOCK_TIME_TRANSACTION_POOL_WINDOW;
+
+            if (m_node.getLastKnownBlockHeight() > CryptoNote::parameters::UNLOCK_TIME_HEIGHT_V2)
+            {
+                unlock_blocks = CryptoNote::parameters::UNLOCK_TIME_TRANSACTION_POOL_WINDOW_V2;
+            }
+
             sendingTransaction.unlockTimestamp = m_node.getLastKnownBlockHeight()
-                + CryptoNote::parameters::UNLOCK_TIME_TRANSACTION_POOL_WINDOW
+                + unlock_blocks
                 + CryptoNote::parameters::MINIMUM_UNLOCK_TIME_BLOCKS;
         }
 

--- a/src/wallet/WalletGreen.cpp
+++ b/src/wallet/WalletGreen.cpp
@@ -1774,9 +1774,16 @@ namespace CryptoNote
 
             if (!fee.isFixedFee)
             {
-                const double feePerByte = fee.isFeePerByte
+                double feePerByte = fee.isFeePerByte
                     ? fee.feePerByte
                     : CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1;
+
+                if (m_node.getLastKnownBlockHeight() > CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V2)
+                {
+                    feePerByte = fee.isFeePerByte
+                        ? fee.feePerByte
+                        : CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V2;
+                }
 
                 /* If we haven't made an estimate already */
                 if (estimatedFee == 0)

--- a/src/wallet/WalletGreen.cpp
+++ b/src/wallet/WalletGreen.cpp
@@ -1785,7 +1785,7 @@ namespace CryptoNote
                     ? fee.feePerByte
                     : CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1;
 
-                if (m_node.getLastKnownBlockHeight() > CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V2)
+                if (m_node.getLastKnownBlockHeight() > CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V2_HEIGHT)
                 {
                     feePerByte = fee.isFeePerByte
                         ? fee.feePerByte

--- a/src/walletbackend/Transfer.cpp
+++ b/src/walletbackend/Transfer.cpp
@@ -416,9 +416,16 @@ namespace SendTransaction
                         extraData.size()
                     );
 
-                    const double feePerByte = fee.isFeePerByte
+                    double feePerByte = fee.isFeePerByte
                         ? fee.feePerByte
                         : CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1;
+
+                    if (daemon->networkBlockCount() > CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V2)
+                    {
+                        feePerByte = fee.isFeePerByte
+                            ? fee.feePerByte
+                            : CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V2;
+                    }
 
                     const uint64_t estimatedFee = Utilities::getTransactionFee(
                         transactionSize,
@@ -1570,9 +1577,16 @@ namespace SendTransaction
             }
             else
             {
-                const double feePerByte = expectedFee.isFeePerByte
+                double feePerByte = expectedFee.isFeePerByte
                     ? expectedFee.feePerByte
                     : CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1;
+                    
+                if (height > CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V2_HEIGHT)
+                {
+                    feePerByte = expectedFee.isFeePerByte
+                        ? expectedFee.feePerByte
+                        : CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V2;
+                }
 
                 const size_t txSize = toBinaryArray(tx).size();
 

--- a/src/walletbackend/Transfer.cpp
+++ b/src/walletbackend/Transfer.cpp
@@ -434,7 +434,7 @@ namespace SendTransaction
                         ? fee.feePerByte
                         : CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V1;
 
-                    if (daemon->networkBlockCount() > CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V2)
+                    if (daemon->networkBlockCount() > CryptoNote::parameters::MINIMUM_FEE_PER_BYTE_V2_HEIGHT)
                     {
                         feePerByte = fee.isFeePerByte
                             ? fee.feePerByte

--- a/src/walletbackend/Transfer.cpp
+++ b/src/walletbackend/Transfer.cpp
@@ -172,8 +172,15 @@ namespace SendTransaction
                 continue;
             }
 
+            uint64_t unlock_blocks = CryptoNote::parameters::UNLOCK_TIME_TRANSACTION_POOL_WINDOW;
+
+            if (daemon->networkBlockCount() > CryptoNote::parameters::UNLOCK_TIME_HEIGHT_V2)
+            {
+                unlock_blocks = CryptoNote::parameters::UNLOCK_TIME_TRANSACTION_POOL_WINDOW_V2;
+            }
+
             const uint64_t unlockTime = daemon->networkBlockCount()
-                + CryptoNote::parameters::UNLOCK_TIME_TRANSACTION_POOL_WINDOW
+                + unlock_blocks
                 + CryptoNote::parameters::MINIMUM_UNLOCK_TIME_BLOCKS;
 
             WalletTypes::TransactionResult txResult =
@@ -320,8 +327,15 @@ namespace SendTransaction
 
         if (unlockTime == 0)
         {
+            uint64_t unlock_blocks = CryptoNote::parameters::UNLOCK_TIME_TRANSACTION_POOL_WINDOW;
+            
+            if (daemon->networkBlockCount() > CryptoNote::parameters::UNLOCK_TIME_HEIGHT_V2)
+            {
+                unlock_blocks = CryptoNote::parameters::UNLOCK_TIME_TRANSACTION_POOL_WINDOW_V2;
+            }
+            
             unlockTime = daemon->networkBlockCount()
-                + CryptoNote::parameters::UNLOCK_TIME_TRANSACTION_POOL_WINDOW
+                + unlock_blocks
                 + CryptoNote::parameters::MINIMUM_UNLOCK_TIME_BLOCKS;
         }
 


### PR DESCRIPTION
* Proposal of new dynamic fee (lower)
```
Params:
    const uint64_t FEE_PER_BYTE_CHUNK_SIZE_V2 = 128;
    const double MINIMUM_FEE_PER_BYTE_V2 = 10.00 / FEE_PER_BYTE_CHUNK_SIZE_V2; 

Samples:
    Size: 2.61 KB, Fee: 2.30 WRKZ
    Size: 2.28 KB, Fee: 2.00 WRKZ
    Size: 21.16 KB, Fee: 17.40 WRKZ
```
* Reduce unlocked blocks from 40 to ~~10 (needs to review)~~ **20**