### PR TITLE
Monitoring daemon crash

### DIFF
--- a/src/cryptonotecore/BlockchainCache.cpp
+++ b/src/cryptonotecore/BlockchainCache.cpp
@@ -581,7 +581,7 @@ namespace CryptoNote
         }
 
         assert(blockIndex - startIndex < blockInfos.size());
-        return blockInfos.get<BlockIndexTag>()[blockIndex - startIndex].blockHash;
+        return blockInfos.get<BlockIndexTag>().at(blockIndex - startIndex).blockHash;
     }
 
     std::vector<Crypto::Hash> BlockchainCache::getBlockHashes(uint32_t startBlockIndex, size_t maxCount) const


### PR DESCRIPTION
Daemon occasionally crash. I made this to easily monitor.
* http://node-fin.wrkz.work:17856/info is running with flag --enable-mining and public. Anyone can use it for mining temporarily.
* Running in debug mode