### PR TITLE
daemon/p2p sync hardening: add peer caps, byte-aware chunking, and bounded orphan recovery

### DIFF
--- a/src/cryptonoteprotocol/CryptoNoteProtocolHandler.cpp
+++ b/src/cryptonoteprotocol/CryptoNoteProtocolHandler.cpp
@@ -35,6 +35,11 @@ namespace CryptoNote
 {
     namespace
     {
+        constexpr uint64_t SYNC_BLOCK_SIZE_ESTIMATE_FLOOR_BYTES = 64 * 1024;
+        constexpr uint64_t SYNC_BLOCK_BUDGET_MIN_BYTES = 2 * 1024 * 1024;
+        constexpr uint64_t SYNC_BLOCK_BUDGET_MAX_BYTES = 48 * 1024 * 1024;
+        constexpr uint32_t SYNC_ORPHAN_RETRY_LIMIT = 3;
+
         bool isPruneCapabilityForkActive(uint64_t localHeight, uint64_t remoteHeight)
         {
             return std::max(localHeight, remoteHeight) >= CryptoNote::parameters::PRUNE_CAPABILITY_FORK_HEIGHT;
@@ -206,10 +211,12 @@ namespace CryptoNote
         m_peersCount(0),
         m_isPrunedNode(false),
         m_prunedNodeDepth(0),
-        m_syncMaxPeers(2),
-        m_syncPeerFailureThreshold(3),
-        m_syncBatchMin(100),
-        m_syncBatchMax(BLOCKS_SYNCHRONIZING_DEFAULT_COUNT),
+        m_syncMaxPeers(3),
+        m_syncPeerFailureThreshold(2),
+        m_syncBatchMin(120),
+        m_syncBatchMax(600),
+        m_syncBlockSyncSize(600),
+        m_syncBlockSyncBytes(16ULL * 1024ULL * 1024ULL),
         m_syncDemotedPeers(0),
         logger(log, "protocol")
     {
@@ -374,6 +381,7 @@ namespace CryptoNote
         context.m_remote_pruned_node_height = hshd.pruned_node_height;
         context.m_sync_batch_size = m_syncBatchMin;
         context.m_sync_failures = 0;
+        context.m_sync_orphan_retries = 0;
 
         if (context.m_state == CryptoNoteConnectionContext::state_befor_handshake && !is_initial)
         {
@@ -745,17 +753,6 @@ namespace CryptoNote
             }
 
             cachedBlocks.emplace_back(blockTemplates[index]);
-            if (index == 1)
-            {
-                if (m_core.hasBlock(cachedBlocks.back().getBlockHash()))
-                { // TODO
-                    context.m_state = CryptoNoteConnectionContext::state_idle;
-                    context.m_needed_objects.clear();
-                    context.m_requested_objects.clear();
-                    logger(Logging::DEBUGGING) << context << "Connection set to idle state.";
-                    return 1;
-                }
-            }
 
             auto req_it = context.m_requested_objects.find(cachedBlocks.back().getBlockHash());
             if (req_it == context.m_requested_objects.end())
@@ -857,10 +854,28 @@ namespace CryptoNote
             }
             else if (addResult == error::AddBlockErrorCondition::BLOCK_REJECTED)
             {
+                ++context.m_sync_orphan_retries;
+
+                if (context.m_sync_orphan_retries >= SYNC_ORPHAN_RETRY_LIMIT)
+                {
+                    logger(Logging::WARNING) << context << "Sync orphan retry limit reached ("
+                                             << context.m_sync_orphan_retries << "/" << SYNC_ORPHAN_RETRY_LIMIT
+                                             << "), dropping connection: " << addResult.message();
+                    context.m_state = CryptoNoteConnectionContext::state_shutdown;
+                    return 1;
+                }
+
                 logger(Logging::INFO) << context
-                                      << "Block received at sync phase was marked as orphaned, dropping connection: "
+                                      << "Block received at sync phase was marked as orphaned. Re-requesting chain "
+                                         "entry from peer (retry "
+                                      << context.m_sync_orphan_retries << "/" << SYNC_ORPHAN_RETRY_LIMIT << "): "
                                       << addResult.message();
-                context.m_state = CryptoNoteConnectionContext::state_shutdown;
+                context.m_needed_objects.clear();
+                context.m_requested_objects.clear();
+                context.m_state = CryptoNoteConnectionContext::state_synchronizing;
+                NOTIFY_REQUEST_CHAIN::request req = boost::value_initialized<NOTIFY_REQUEST_CHAIN::request>();
+                req.block_ids = m_core.buildSparseChain();
+                post_notify<NOTIFY_REQUEST_CHAIN>(*m_p2p, req, context);
                 return 1;
             }
             else if (addResult == error::AddBlockErrorCode::ALREADY_EXISTS)
@@ -1076,7 +1091,20 @@ namespace CryptoNote
             size_t count = 0;
             auto it = context.m_needed_objects.begin();
 
-            const uint32_t batchSize = std::max(m_syncBatchMin, getAdaptiveBatchSize(context));
+            const uint32_t adaptiveBatchSize = std::max(m_syncBatchMin, getAdaptiveBatchSize(context));
+            const uint32_t countLimitedBatch = std::max<uint32_t>(1, std::min(adaptiveBatchSize, m_syncBlockSyncSize));
+
+            const uint64_t avgBlockBytes =
+                context.m_sync_avg_block_bytes > 0 ? context.m_sync_avg_block_bytes : SYNC_BLOCK_SIZE_ESTIMATE_FLOOR_BYTES;
+
+            const uint64_t bytesBudget =
+                std::max<uint64_t>(SYNC_BLOCK_BUDGET_MIN_BYTES, std::min<uint64_t>(m_syncBlockSyncBytes, SYNC_BLOCK_BUDGET_MAX_BYTES));
+
+            const uint32_t bytesLimitedBatch = std::max<uint32_t>(
+                1,
+                static_cast<uint32_t>(bytesBudget / std::max<uint64_t>(avgBlockBytes, SYNC_BLOCK_SIZE_ESTIMATE_FLOOR_BYTES)));
+
+            const uint32_t batchSize = std::max<uint32_t>(1, std::min(countLimitedBatch, bytesLimitedBatch));
 
             while (it != context.m_needed_objects.end() && count < batchSize)
             {
@@ -1510,12 +1538,17 @@ namespace CryptoNote
         uint32_t syncMaxPeers,
         uint32_t syncPeerFailureThreshold,
         uint32_t syncBatchMin,
-        uint32_t syncBatchMax)
+        uint32_t syncBatchMax,
+        uint32_t blockSyncSize,
+        uint64_t blockSyncBytes)
     {
         m_syncMaxPeers = std::max<uint32_t>(1, syncMaxPeers);
         m_syncPeerFailureThreshold = std::max<uint32_t>(1, syncPeerFailureThreshold);
         m_syncBatchMin = std::max<uint32_t>(1, syncBatchMin);
         m_syncBatchMax = std::max<uint32_t>(m_syncBatchMin, syncBatchMax);
+        m_syncBlockSyncSize = std::max<uint32_t>(1, blockSyncSize);
+        m_syncBlockSyncBytes =
+            std::max<uint64_t>(SYNC_BLOCK_BUDGET_MIN_BYTES, std::min<uint64_t>(blockSyncBytes, SYNC_BLOCK_BUDGET_MAX_BYTES));
     }
 
     uint32_t CryptoNoteProtocolHandler::getAdaptiveBatchSize(const CryptoNoteConnectionContext &context) const
@@ -1536,6 +1569,21 @@ namespace CryptoNote
         context.m_sync_bytes_received += bytes;
         context.m_sync_failures = 0;
         context.m_last_sync_progress_ts = static_cast<uint64_t>(std::time(nullptr));
+        context.m_sync_orphan_retries = 0;
+
+        if (blocks > 0)
+        {
+            const uint64_t sampleAvgBlockBytes = std::max<uint64_t>(1, static_cast<uint64_t>(bytes / blocks));
+
+            if (context.m_sync_avg_block_bytes == 0)
+            {
+                context.m_sync_avg_block_bytes = sampleAvgBlockBytes;
+            }
+            else
+            {
+                context.m_sync_avg_block_bytes = ((context.m_sync_avg_block_bytes * 8) + (sampleAvgBlockBytes * 2)) / 10;
+            }
+        }
 
         if (context.m_sync_batch_size < m_syncBatchMax)
         {

--- a/src/cryptonoteprotocol/CryptoNoteProtocolHandler.h
+++ b/src/cryptonoteprotocol/CryptoNoteProtocolHandler.h
@@ -104,7 +104,9 @@ namespace CryptoNote
             uint32_t syncMaxPeers,
             uint32_t syncPeerFailureThreshold,
             uint32_t syncBatchMin,
-            uint32_t syncBatchMax);
+            uint32_t syncBatchMax,
+            uint32_t blockSyncSize,
+            uint64_t blockSyncBytes);
 
         void requestMissingPoolTransactions(const CryptoNoteConnectionContext &context);
 
@@ -234,6 +236,10 @@ namespace CryptoNote
         uint32_t m_syncBatchMin;
 
         uint32_t m_syncBatchMax;
+
+        uint32_t m_syncBlockSyncSize;
+
+        uint64_t m_syncBlockSyncBytes;
 
         std::atomic<uint32_t> m_syncDemotedPeers;
 

--- a/src/daemon/Daemon.cpp
+++ b/src/daemon/Daemon.cpp
@@ -336,6 +336,8 @@ int main(int argc, char *argv[])
             config.p2pInterface,
             config.p2pPort,
             config.p2pExternalPort,
+            config.p2pOutPeers,
+            config.p2pInPeers,
             config.localIp,
             config.hideMyPort,
             config.dataDirectory,
@@ -459,7 +461,9 @@ int main(int argc, char *argv[])
             config.syncMaxPeers,
             config.syncPeerFailureThreshold,
             config.syncBatchMin,
-            config.syncBatchMax);
+            config.syncBatchMax,
+            config.blockSyncSize,
+            config.blockSyncBytes);
 
         const auto p2psrv = std::make_shared<CryptoNote::NodeServer>(
             dispatcher,

--- a/src/daemon/DaemonCommandsHandler.cpp
+++ b/src/daemon/DaemonCommandsHandler.cpp
@@ -804,11 +804,18 @@ bool DaemonCommandsHandler::sync_tune(const std::vector<std::string> &args)
               << SuccessMsg(std::to_string(getUint64FromJSON(resp, "sync_demoted_peers"))) << std::endl;
     std::cout << InformationMsg("Configured Sync Max Peers: ")
               << SuccessMsg(std::to_string(m_config.syncMaxPeers)) << std::endl;
+    std::cout << InformationMsg("Configured P2P Out/In Peers: ")
+              << SuccessMsg(std::to_string(m_config.p2pOutPeers) + "/" + std::to_string(m_config.p2pInPeers))
+              << std::endl;
     std::cout << InformationMsg("Configured Sync Failure Threshold: ")
               << SuccessMsg(std::to_string(m_config.syncPeerFailureThreshold)) << std::endl;
     std::cout << InformationMsg("Configured Sync Batch Min/Max: ")
               << SuccessMsg(std::to_string(m_config.syncBatchMin) + "/" + std::to_string(m_config.syncBatchMax))
               << std::endl;
+    std::cout << InformationMsg("Configured Block Sync Size: ")
+              << SuccessMsg(std::to_string(m_config.blockSyncSize)) << std::endl;
+    std::cout << InformationMsg("Configured Block Sync Bytes: ")
+              << SuccessMsg(Utilities::prettyPrintBytes(m_config.blockSyncBytes)) << std::endl;
 
     return true;
 }

--- a/src/daemon/DaemonCommandsHandler.cpp
+++ b/src/daemon/DaemonCommandsHandler.cpp
@@ -33,6 +33,7 @@ namespace
     const char *COMPACTION_MARKER_FILE = ".compact_db_in_progress";
     constexpr uint64_t AUTO_COMPACTION_CHECK_INTERVAL_SECONDS = 300;
     constexpr uint64_t AUTO_COMPACTION_MIN_GAP_SECONDS = 6 * 60 * 60;
+    constexpr uint64_t AUTO_PRUNE_MIN_GAP_SECONDS = 5 * 60;
 
     template<typename T> static bool print_as_json(const T &obj)
     {
@@ -267,9 +268,8 @@ void DaemonCommandsHandler::start_boot_compaction_if_needed()
     {
         std::cout << InformationMsg("Boot DB compaction: skipped by configuration (--skip-boot-compaction).")
                   << std::endl;
-        return;
     }
-
+    else
     {
         std::lock_guard<std::mutex> lock(m_compactionMutex);
         refresh_compaction_state_locked();
@@ -1042,12 +1042,32 @@ void DaemonCommandsHandler::compaction_scheduler_loop()
         std::lock_guard<std::mutex> lock(m_compactionMutex);
         refresh_compaction_state_locked();
 
+        const uint64_t now = static_cast<uint64_t>(time(nullptr));
+
+        if (m_config.prune
+            && (m_lastAutoPruneAt == 0 || (now > m_lastAutoPruneAt && (now - m_lastAutoPruneAt) >= AUTO_PRUNE_MIN_GAP_SECONDS)))
+        {
+            logger(Logging::INFO)
+                << "Starting periodic prune pass in background (depth " << m_config.pruneDepth << ").";
+
+            try
+            {
+                const auto prunedBlocks = m_core.pruneRawBlocks(m_config.pruneDepth);
+                logger(Logging::INFO) << "Periodic prune pass completed. Raw block slots processed: " << prunedBlocks;
+            }
+            catch (const std::exception &e)
+            {
+                logger(Logging::WARNING) << "Periodic prune pass failed: " << e.what();
+            }
+
+            m_lastAutoPruneAt = now;
+        }
+
         if (m_compactionRunning)
         {
             continue;
         }
 
-        const uint64_t now = static_cast<uint64_t>(time(nullptr));
         const uint64_t lastActivity = std::max(m_compactionStartedAt, m_compactionFinishedAt);
 
         if (lastActivity != 0 && now > lastActivity && (now - lastActivity) < AUTO_COMPACTION_MIN_GAP_SECONDS)

--- a/src/daemon/DaemonCommandsHandler.h
+++ b/src/daemon/DaemonCommandsHandler.h
@@ -145,4 +145,6 @@ class DaemonCommandsHandler
     std::thread m_compactionSchedulerThread;
 
     std::atomic<bool> m_stopCompactionScheduler {false};
+
+    uint64_t m_lastAutoPruneAt = 0;
 };

--- a/src/daemon/DaemonConfiguration.cpp
+++ b/src/daemon/DaemonConfiguration.cpp
@@ -42,6 +42,23 @@ namespace DaemonConfig
 
             return DaemonConfiguration::MIN_PRUNE_DEPTH;
         }
+
+        uint32_t clampSyncMaxPeersToOutPeers(
+            const uint32_t syncMaxPeers,
+            const uint32_t outPeers,
+            const std::string &source)
+        {
+            if (syncMaxPeers <= outPeers)
+            {
+                return syncMaxPeers;
+            }
+
+            std::cout << CryptoNote::getProjectCLIHeader() << "The configured sync-max-peers (" << syncMaxPeers
+                      << ") from " << source << " exceeds out-peers (" << outPeers
+                      << "). Using out-peers value to avoid oversubscription." << std::endl;
+
+            return outPeers;
+        }
     } // namespace
 
     DaemonConfiguration initConfiguration(const char *path)
@@ -199,6 +216,14 @@ namespace DaemonConfig
             "External TCP port for the P2P service (NAT port forward)",
             cxxopts::value<int>()->default_value("0"),
             "#")(
+            "out-peers",
+            "Maximum number of outgoing P2P connections",
+            cxxopts::value<uint32_t>()->default_value(std::to_string(config.p2pOutPeers)),
+            "#")(
+            "in-peers",
+            "Maximum number of incoming P2P connections",
+            cxxopts::value<uint32_t>()->default_value(std::to_string(config.p2pInPeers)),
+            "#")(
             "p2p-reset-peerstate",
             "Generate a new peer ID and remove known peers saved previously",
             cxxopts::value<bool>()->default_value("false")->implicit_value("true"))(
@@ -279,6 +304,14 @@ namespace DaemonConfig
             "sync-batch-max",
             "Maximum adaptive block request batch size",
             cxxopts::value<uint32_t>()->default_value(std::to_string(config.syncBatchMax)),
+            "#")(
+            "block-sync-size",
+            "Maximum number of blocks requested per sync chunk",
+            cxxopts::value<uint32_t>()->default_value(std::to_string(config.blockSyncSize)),
+            "#")(
+            "block-sync-bytes",
+            "Maximum approximate bytes requested per sync chunk",
+            cxxopts::value<uint64_t>()->default_value(std::to_string(config.blockSyncBytes)),
             "#");
 
         try
@@ -448,6 +481,16 @@ namespace DaemonConfig
                 config.p2pExternalPort = cli["p2p-external-port"].as<int>();
             }
 
+            if (cli.count("out-peers") > 0)
+            {
+                config.p2pOutPeers = std::max<uint32_t>(1, cli["out-peers"].as<uint32_t>());
+            }
+
+            if (cli.count("in-peers") > 0)
+            {
+                config.p2pInPeers = cli["in-peers"].as<uint32_t>();
+            }
+
             if (cli.count("p2p-reset-peerstate") > 0)
             {
                 config.p2pResetPeerstate = cli["p2p-reset-peerstate"].as<bool>();
@@ -579,6 +622,18 @@ namespace DaemonConfig
             {
                 config.syncBatchMax = std::max<uint32_t>(config.syncBatchMin, cli["sync-batch-max"].as<uint32_t>());
             }
+
+            if (cli.count("block-sync-size") > 0)
+            {
+                config.blockSyncSize = std::max<uint32_t>(1, cli["block-sync-size"].as<uint32_t>());
+            }
+
+            if (cli.count("block-sync-bytes") > 0)
+            {
+                config.blockSyncBytes = std::max<uint64_t>(2 * 1024 * 1024, cli["block-sync-bytes"].as<uint64_t>());
+            }
+
+            config.syncMaxPeers = clampSyncMaxPeersToOutPeers(config.syncMaxPeers, config.p2pOutPeers, "CLI/default");
 
             if (config.help) // Do we want to display the help message?
             {
@@ -773,6 +828,30 @@ namespace DaemonConfig
                         throw std::runtime_error(std::string(e.what()) + " - Invalid value for " + cfgKey);
                     }
                 }
+                else if (cfgKey.compare("out-peers") == 0)
+                {
+                    try
+                    {
+                        config.p2pOutPeers = std::max<uint32_t>(1, std::stoul(cfgValue));
+                        updated = true;
+                    }
+                    catch (std::exception &e)
+                    {
+                        throw std::runtime_error(std::string(e.what()) + " - Invalid value for " + cfgKey);
+                    }
+                }
+                else if (cfgKey.compare("in-peers") == 0)
+                {
+                    try
+                    {
+                        config.p2pInPeers = std::stoul(cfgValue);
+                        updated = true;
+                    }
+                    catch (std::exception &e)
+                    {
+                        throw std::runtime_error(std::string(e.what()) + " - Invalid value for " + cfgKey);
+                    }
+                }
                 else if (cfgKey.compare("rpc-bind-ip") == 0)
                 {
                     config.rpcInterface = cfgValue;
@@ -951,6 +1030,78 @@ namespace DaemonConfig
                         throw std::runtime_error(std::string(e.what()) + " - Invalid value for " + cfgKey);
                     }
                 }
+                else if (cfgKey.compare("sync-max-peers") == 0)
+                {
+                    try
+                    {
+                        config.syncMaxPeers = std::max<uint32_t>(1, std::stoul(cfgValue));
+                        updated = true;
+                    }
+                    catch (std::exception &e)
+                    {
+                        throw std::runtime_error(std::string(e.what()) + " - Invalid value for " + cfgKey);
+                    }
+                }
+                else if (cfgKey.compare("sync-peer-failure-threshold") == 0)
+                {
+                    try
+                    {
+                        config.syncPeerFailureThreshold = std::max<uint32_t>(1, std::stoul(cfgValue));
+                        updated = true;
+                    }
+                    catch (std::exception &e)
+                    {
+                        throw std::runtime_error(std::string(e.what()) + " - Invalid value for " + cfgKey);
+                    }
+                }
+                else if (cfgKey.compare("sync-batch-min") == 0)
+                {
+                    try
+                    {
+                        config.syncBatchMin = std::max<uint32_t>(1, std::stoul(cfgValue));
+                        updated = true;
+                    }
+                    catch (std::exception &e)
+                    {
+                        throw std::runtime_error(std::string(e.what()) + " - Invalid value for " + cfgKey);
+                    }
+                }
+                else if (cfgKey.compare("sync-batch-max") == 0)
+                {
+                    try
+                    {
+                        config.syncBatchMax = std::max<uint32_t>(config.syncBatchMin, std::stoul(cfgValue));
+                        updated = true;
+                    }
+                    catch (std::exception &e)
+                    {
+                        throw std::runtime_error(std::string(e.what()) + " - Invalid value for " + cfgKey);
+                    }
+                }
+                else if (cfgKey.compare("block-sync-size") == 0)
+                {
+                    try
+                    {
+                        config.blockSyncSize = std::max<uint32_t>(1, std::stoul(cfgValue));
+                        updated = true;
+                    }
+                    catch (std::exception &e)
+                    {
+                        throw std::runtime_error(std::string(e.what()) + " - Invalid value for " + cfgKey);
+                    }
+                }
+                else if (cfgKey.compare("block-sync-bytes") == 0)
+                {
+                    try
+                    {
+                        config.blockSyncBytes = std::max<uint64_t>(2 * 1024 * 1024, std::stoull(cfgValue));
+                        updated = true;
+                    }
+                    catch (std::exception &e)
+                    {
+                        throw std::runtime_error(std::string(e.what()) + " - Invalid value for " + cfgKey);
+                    }
+                }
                 else
                 {
                     for (auto c : cfgKey)
@@ -964,6 +1115,8 @@ namespace DaemonConfig
                 }
             }
         }
+
+        config.syncMaxPeers = clampSyncMaxPeersToOutPeers(config.syncMaxPeers, config.p2pOutPeers, "config file");
 
         if (!updated)
         {
@@ -1081,6 +1234,16 @@ namespace DaemonConfig
         if (j.HasMember("p2p-external-port"))
         {
             config.p2pExternalPort = j["p2p-external-port"].GetInt();
+        }
+
+        if (j.HasMember("out-peers"))
+        {
+            config.p2pOutPeers = std::max<uint32_t>(1, j["out-peers"].GetUint());
+        }
+
+        if (j.HasMember("in-peers"))
+        {
+            config.p2pInPeers = j["in-peers"].GetUint();
         }
 
         if (j.HasMember("p2p-reset-peerstate"))
@@ -1229,6 +1392,16 @@ namespace DaemonConfig
             config.syncBatchMax = std::max<uint32_t>(config.syncBatchMin, j["sync-batch-max"].GetUint());
         }
 
+        if (j.HasMember("block-sync-size"))
+        {
+            config.blockSyncSize = std::max<uint32_t>(1, j["block-sync-size"].GetUint());
+        }
+
+        if (j.HasMember("block-sync-bytes"))
+        {
+            config.blockSyncBytes = std::max<uint64_t>(2 * 1024 * 1024, j["block-sync-bytes"].GetUint64());
+        }
+
         if (j.HasMember("prune"))
         {
             config.prune = j["prune"].GetBool();
@@ -1238,6 +1411,8 @@ namespace DaemonConfig
         {
             config.pruneDepth = clampPruneDepth(j["prune-depth"].GetUint(), "config file");
         }
+
+        config.syncMaxPeers = clampSyncMaxPeersToOutPeers(config.syncMaxPeers, config.p2pOutPeers, "config file");
     }
 
     Document asJSON(const DaemonConfiguration &config)
@@ -1262,6 +1437,8 @@ namespace DaemonConfig
         j.AddMember("p2p-bind-ip", config.p2pInterface, alloc);
         j.AddMember("p2p-bind-port", config.p2pPort, alloc);
         j.AddMember("p2p-external-port", config.p2pExternalPort, alloc);
+        j.AddMember("out-peers", config.p2pOutPeers, alloc);
+        j.AddMember("in-peers", config.p2pInPeers, alloc);
         j.AddMember("p2p-reset-peerstate", config.p2pResetPeerstate, alloc);
         j.AddMember("rpc-bind-ip", config.rpcInterface, alloc);
         j.AddMember("rpc-bind-port", config.rpcPort, alloc);
@@ -1323,6 +1500,8 @@ namespace DaemonConfig
         j.AddMember("sync-peer-failure-threshold", config.syncPeerFailureThreshold, alloc);
         j.AddMember("sync-batch-min", config.syncBatchMin, alloc);
         j.AddMember("sync-batch-max", config.syncBatchMax, alloc);
+        j.AddMember("block-sync-size", config.blockSyncSize, alloc);
+        j.AddMember("block-sync-bytes", config.blockSyncBytes, alloc);
 
         return j;
     }

--- a/src/daemon/DaemonConfiguration.h
+++ b/src/daemon/DaemonConfiguration.h
@@ -39,6 +39,8 @@ namespace DaemonConfig
             p2pInterface = "0.0.0.0";
             p2pPort = CryptoNote::P2P_DEFAULT_PORT;
             p2pExternalPort = 0;
+            p2pOutPeers = CryptoNote::P2P_DEFAULT_CONNECTIONS_COUNT;
+            p2pInPeers = CryptoNote::P2P_DEFAULT_CONNECTIONS_COUNT;
             transactionValidationThreads = std::thread::hardware_concurrency();
             rpcInterface = "127.0.0.1";
             rpcPort = CryptoNote::RPC_DEFAULT_PORT;
@@ -61,10 +63,12 @@ namespace DaemonConfig
             exportNumBlocks = 0;
             prune = false;
             pruneDepth = DEFAULT_PRUNE_DEPTH;
-            syncMaxPeers = 2;
-            syncPeerFailureThreshold = 3;
-            syncBatchMin = 100;
-            syncBatchMax = 400;
+            syncMaxPeers = 3;
+            syncPeerFailureThreshold = 2;
+            syncBatchMin = 120;
+            syncBatchMax = 600;
+            blockSyncSize = syncBatchMax;
+            blockSyncBytes = 16ULL * 1024ULL * 1024ULL;
             rpcAccessToken = "";
             rpcReadTimeout = 15;
             rpcWriteTimeout = 30;
@@ -107,6 +111,10 @@ namespace DaemonConfig
         int p2pPort;
 
         int p2pExternalPort;
+
+        uint32_t p2pOutPeers;
+
+        uint32_t p2pInPeers;
 
         uint32_t transactionValidationThreads;
 
@@ -153,6 +161,10 @@ namespace DaemonConfig
         uint32_t syncBatchMin;
 
         uint32_t syncBatchMax;
+
+        uint32_t blockSyncSize;
+
+        uint64_t blockSyncBytes;
 
         std::string rpcAccessToken;
 

--- a/src/p2p/ConnectionContext.h
+++ b/src/p2p/ConnectionContext.h
@@ -50,7 +50,9 @@ namespace CryptoNote
         uint32_t m_sync_batch_size = 100;
         uint64_t m_sync_blocks_received = 0;
         uint64_t m_sync_bytes_received = 0;
+        uint64_t m_sync_avg_block_bytes = 0;
         uint32_t m_sync_failures = 0;
+        uint32_t m_sync_orphan_retries = 0;
         uint64_t m_last_sync_progress_ts = 0;
     };
 

--- a/src/p2p/NetNode.cpp
+++ b/src/p2p/NetNode.cpp
@@ -58,6 +58,9 @@ using namespace CryptoNote;
 
 namespace
 {
+    constexpr size_t PEER_SELECTION_RECENCY_WINDOW = 256;
+    constexpr size_t PEER_SELECTION_MAX_TRIES = 16;
+
     size_t get_random_index_with_fixed_probability(size_t max_index)
     {
         // divide by zero workaround
@@ -231,6 +234,8 @@ namespace CryptoNote
         m_payload_handler(payload_handler),
         m_allow_local_ip(false),
         m_hide_my_port(false),
+        m_targetOutgoingConnections(CryptoNote::P2P_DEFAULT_CONNECTIONS_COUNT),
+        m_maxIncomingConnections(CryptoNote::P2P_DEFAULT_CONNECTIONS_COUNT),
         m_network_id(CryptoNote::CRYPTONOTE_NETWORK),
         logger(log, "node_server"),
         m_stopEvent(m_dispatcher),
@@ -423,6 +428,8 @@ namespace CryptoNote
         m_bind_ip = config.getBindIp();
         m_port = std::to_string(config.getBindPort());
         m_external_port = config.getExternalPort();
+        m_targetOutgoingConnections = std::max<uint32_t>(1, config.getOutPeers());
+        m_maxIncomingConnections = config.getInPeers();
         m_allow_local_ip = config.getAllowLocalIp();
 
         auto peers = config.getPeers();
@@ -495,6 +502,8 @@ namespace CryptoNote
             logger(ERROR, BRIGHT_RED) << "Failed to init config.";
             return false;
         }
+
+        m_config.m_net_config.connections_count = m_targetOutgoingConnections;
 
         if (!m_peerlist.init(m_allow_local_ip))
         {
@@ -928,13 +937,13 @@ namespace CryptoNote
             return false;
         } // no peers
 
-        size_t max_random_index = std::min<uint64_t>(local_peers_count - 1, 20);
+        size_t max_random_index = std::min<uint64_t>(local_peers_count - 1, PEER_SELECTION_RECENCY_WINDOW);
 
         std::set<size_t> tried_peers;
 
         size_t try_count = 0;
         size_t rand_count = 0;
-        while (rand_count < (max_random_index + 1) * 3 && try_count < 10 && !m_stop)
+        while (rand_count < (max_random_index + 1) * 3 && try_count < PEER_SELECTION_MAX_TRIES && !m_stop)
         {
             ++rand_count;
             size_t random_index = get_random_index_with_fixed_probability(max_random_index);
@@ -1642,6 +1651,23 @@ namespace CryptoNote
                 if (isHostBanned(ctx.m_remote_ip))
                 {
                     logger(DEBUGGING) << "Rejecting incoming connection from banned host "
+                                      << Common::ipAddressToString(ctx.m_remote_ip) << ":" << ctx.m_remote_port;
+                    continue;
+                }
+
+                size_t incomingConnections = 0;
+                for (const auto &kv : m_connections)
+                {
+                    if (kv.second.m_is_income)
+                    {
+                        ++incomingConnections;
+                    }
+                }
+
+                if (incomingConnections >= m_maxIncomingConnections)
+                {
+                    logger(DEBUGGING) << "Rejecting incoming connection due to --in-peers limit ("
+                                      << incomingConnections << "/" << m_maxIncomingConnections << ") from "
                                       << Common::ipAddressToString(ctx.m_remote_ip) << ":" << ctx.m_remote_port;
                     continue;
                 }

--- a/src/p2p/NetNode.h
+++ b/src/p2p/NetNode.h
@@ -368,6 +368,10 @@ namespace CryptoNote
 
         bool m_hide_my_port;
 
+        uint32_t m_targetOutgoingConnections;
+
+        uint32_t m_maxIncomingConnections;
+
         std::string m_p2p_state_filename;
 
         bool m_p2p_state_reset;

--- a/src/p2p/NetNodeConfig.cpp
+++ b/src/p2p/NetNodeConfig.cpp
@@ -62,6 +62,8 @@ namespace CryptoNote
         bindIp = "";
         bindPort = 0;
         externalPort = 0;
+        outPeers = CryptoNote::P2P_DEFAULT_CONNECTIONS_COUNT;
+        inPeers = CryptoNote::P2P_DEFAULT_CONNECTIONS_COUNT;
         allowLocalIp = false;
         hideMyPort = false;
         configFolder = Tools::getDefaultDataDirectory();
@@ -72,6 +74,8 @@ namespace CryptoNote
         const std::string interface,
         const int port,
         const int external,
+        const uint32_t outPeersCount,
+        const uint32_t inPeersCount,
         const bool localIp,
         const bool hidePort,
         const std::string dataDir,
@@ -84,6 +88,8 @@ namespace CryptoNote
         bindIp = interface;
         bindPort = port;
         externalPort = external;
+        outPeers = outPeersCount;
+        inPeers = inPeersCount;
         allowLocalIp = localIp;
         hideMyPort = hidePort;
         configFolder = dataDir;
@@ -148,6 +154,16 @@ namespace CryptoNote
     uint16_t NetNodeConfig::getExternalPort() const
     {
         return externalPort;
+    }
+
+    uint32_t NetNodeConfig::getOutPeers() const
+    {
+        return outPeers;
+    }
+
+    uint32_t NetNodeConfig::getInPeers() const
+    {
+        return inPeers;
     }
 
     bool NetNodeConfig::getAllowLocalIp() const

--- a/src/p2p/NetNodeConfig.h
+++ b/src/p2p/NetNodeConfig.h
@@ -24,6 +24,8 @@ namespace CryptoNote
             const std::string interface,
             const int port,
             const int external,
+            const uint32_t outPeers,
+            const uint32_t inPeers,
             const bool localIp,
             const bool hidePort,
             const std::string dataDir,
@@ -42,6 +44,10 @@ namespace CryptoNote
         uint16_t getBindPort() const;
 
         uint16_t getExternalPort() const;
+
+        uint32_t getOutPeers() const;
+
+        uint32_t getInPeers() const;
 
         bool getAllowLocalIp() const;
 
@@ -63,6 +69,10 @@ namespace CryptoNote
         uint16_t bindPort;
 
         uint16_t externalPort;
+
+        uint32_t outPeers;
+
+        uint32_t inPeers;
 
         bool allowLocalIp;
 


### PR DESCRIPTION
Adds --out-peers/--in-peers, --block-sync-size, and --block-sync-bytes (default 16MB; 2MB..48MB clamp), clamps sync-max-peers to out-peers, introduces per-peer avg block-size based byte-aware sync chunking, and limits orphan retry loops (3 retries) before dropping bad peers; console sync tuning output was updated to show new settings.